### PR TITLE
Updated to make the modal display and behave properly on pages with scroll bars

### DIFF
--- a/src/ng-modal.less
+++ b/src/ng-modal.less
@@ -1,5 +1,5 @@
 .ng-modal-overlay {
-  position:absolute;
+  position:fixed;
   z-index:9999;
   top:0;
   left:0;
@@ -10,7 +10,7 @@
 }
 .ng-modal-dialog {
   z-index:10000;
-  position: absolute;
+  position: fixed;
   top: 50%;
   left: 50%;
   width: 50%;


### PR DESCRIPTION
I have a web app that has too much content to fit on one page, so I have scroll bars.  I had to make the change in this Pull Request for my application, so I thought I'd give back.  It doesn't matter where you are scrolled on the page; the modal dialog will appear in the center of the page and disable the scroll bars.  

Thank you for sharing your outstanding work.  This helped me tremendously get a jump start.  

Thanks,
Joe
