### PR TITLE
Change closes buttons to &times; instead the letter 'X'

### DIFF
--- a/dist/ng-modal.css
+++ b/dist/ng-modal.css
@@ -44,7 +44,7 @@
   top: 3px;
   right: 5px;
   cursor: pointer;
-  font-size: 120%;
+  font-size: 180%;
   padding: 5px;
   display: inline-block;
 }

--- a/dist/ng-modal.js
+++ b/dist/ng-modal.js
@@ -6,7 +6,7 @@
   app.provider("ngModalDefaults", function() {
     return {
       options: {
-        closeButtonHtml: "<span class='ng-modal-close-x'>X</span>"
+        closeButtonHtml: "<span class='ng-modal-close-x'>&times;</span>"
       },
       $get: function() {
         return this.options;

--- a/src/ng-modal.coffee
+++ b/src/ng-modal.coffee
@@ -12,7 +12,7 @@ app = angular.module("ngModal", [])
 
 app.provider "ngModalDefaults", ->
   options: {
-    closeButtonHtml: "<span class='ng-modal-close-x'>X</span>"
+    closeButtonHtml: "<span class='ng-modal-close-x'>&times;</span>"
   }
   $get: ->
     @options

--- a/src/ng-modal.less
+++ b/src/ng-modal.less
@@ -45,7 +45,7 @@
   top: 3px;
   right: 5px;
   cursor: pointer;
-  font-size: 120%;
+  font-size: 180%;
   padding: 5px;
   display: inline-block;
 }


### PR DESCRIPTION
Hi,

I think that the unicode &times; is most "consistent" to use instead the letter X. What do you think?

Using the letter "X";
![](http://f.cl.ly/items/09320M2E001d1l1e1S1y/Screen%20Shot%202014-09-22%20at%2011.49.37.png)

Using the &times; unicode
![](http://f.cl.ly/items/3z3A2a3h3u3e2q30003M/Screen%20Shot%202014-09-22%20at%2011.50.05.png)

:smile_cat: 
